### PR TITLE
return statement if no args specified

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -123,7 +123,10 @@ func prepareExecPostRequest(conn *Conn, q Query) (*http.Request, error) {
 }
 
 func prepareHttp(stmt string, args []interface{}) string {
-
+	if len(args) == 0 {
+		return stmt
+	}
+	
 	var res []byte
 
 	buf := []byte(stmt)


### PR DESCRIPTION
this part of code was causing big memory leak when i was trying to send inserts with 10000 rows